### PR TITLE
Import Bitwarden nested and custom fields

### DIFF
--- a/docs/updatedoc.py
+++ b/docs/updatedoc.py
@@ -38,7 +38,7 @@ def replace(marker_begin, marker_end, string, newcontent):
 
 
 class ManagerMeta():
-    """Generate currated password managers metadata."""
+    """Generate curated password managers metadata."""
     guide = 'this guide: '
 
     def __init__(self, pm, ext=True, md=True):

--- a/pass_import/managers/bitwarden.py
+++ b/pass_import/managers/bitwarden.py
@@ -22,7 +22,8 @@ class BitwardenCSV(CSV):
         'login': 'login_username',
         'url': 'login_uri',
         'comments': 'notes',
-        'group': 'folder'
+        'group': 'folder',
+        'otpauth': 'login_totp',
     }
 
 
@@ -33,7 +34,7 @@ class BitwardenJSON(JSON):
     url = 'https://bitwarden.com'
     hexport = 'Tools> Export Vault> File Format: .json'
     himport = 'pass import bitwarden file.json'
-    ignore = {'login', 'id', 'folderId'}
+    ignore = {'login', 'id', 'folderId', 'secureNote', 'type', 'favorite'}
     keys = {
         'title': 'name',
         'password': 'password',
@@ -53,10 +54,6 @@ class BitwardenJSON(JSON):
             'type': int,
             'name': str,
             'favorite': bool,
-            'login': {
-                'username': str,
-                'password': str,
-            },
         }],
     }
 

--- a/pass_import/managers/dashlane.py
+++ b/pass_import/managers/dashlane.py
@@ -47,7 +47,7 @@ class DashlaneJSON(JSON):
     }
 
     def parse(self):
-        """Parse Bitwarden JSON file."""
+        """Parse Dashlane JSON file."""
         jsons = json.loads(self.file.read())
         keys = self.invkeys()
         for item in jsons.get('AUTHENTIFIANT', {}):

--- a/pass_import/tools.py
+++ b/pass_import/tools.py
@@ -140,7 +140,7 @@ class Config(dict):
             clean.CLEANS[' '] = self['separator']
 
     def currate(self):
-        """Generate currated config from pass-import and pimport arguments."""
+        """Generate curated config from pass-import and pimport arguments."""
         self['exporter'] = self.pop('dst', '')
         if self.passwordstore:
             self['exporter'] = 'pass'
@@ -149,7 +149,7 @@ class Config(dict):
             self['list_exporters'] = False
 
     def getsettings(self, root='', action=Cap.IMPORT):
-        """Return a currated setting dict for use in a manager class."""
+        """Return a curated setting dict for use in a manager class."""
         settings = {'action': action, 'root': root}
         keep = {
             'all', 'force', 'delimiter', 'cols', '1password', 'lastpass',

--- a/tests/assets/db/bitwarden-other.csv
+++ b/tests/assets/db/bitwarden-other.csv
@@ -1,0 +1,4 @@
+folder,favorite,type,name,notes,fields,login_uri,login_username,login_password,login_totp
+Bank,,login,aib,,,https://onlinebanking.aib.ie,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",S3K3TPI5MYA2M67V
+,,note,Some Note,This is a note sample.,,,,,
+,1,login,Some note only item,Hello World!,,,,,

--- a/tests/assets/db/bitwarden-other.json
+++ b/tests/assets/db/bitwarden-other.json
@@ -1,0 +1,174 @@
+{
+  "folders": [
+    {
+      "id": "f694c031-d547-421c-93e1-aad30008b3e1",
+      "name": "Bank"
+    },
+    {
+      "id": "5a222291-0d9f-4ca6-96b8-aad30008b3e1",
+      "name": "CornerCases"
+    },
+    {
+      "id": "bcda1361-ed24-4b10-90ba-aad30008b3e1",
+      "name": "Emails"
+    },
+    {
+      "id": "b4eaaf60-9486-4cbb-b178-aad30008b3e1",
+      "name": "Emails/WS"
+    },
+    {
+      "id": "5da50eb7-767b-4d93-aa47-aad30008b3e1",
+      "name": "Servers"
+    },
+    {
+      "id": "9acaec4b-f9b8-476c-8c96-aad30008b3e1",
+      "name": "Social"
+    }
+  ],
+  "items": [
+    {
+      "id": "6f71426f-fc6e-4d81-a85b-aad30008b3e1",
+      "organizationId": null,
+      "folderId": "f694c031-d547-421c-93e1-aad30008b3e1",
+      "type": 1,
+      "name": "aib",
+      "notes": null,
+      "favorite": false,
+      "login": {
+        "uris": [
+          {
+            "match": null,
+            "uri": "https://onlinebanking.aib.ie"
+          }
+        ],
+        "username": "dpbx@fner.ws",
+        "password": "ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",
+        "totp": "S3K3TPI5MYA2M67V"
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "70488eea-fb65-4a26-a1a4-a8aa01734b3f",
+      "organizationId": null,
+      "folderId": "5a222291-0d9f-4ca6-96b8-aad30008b3e1",
+      "type": 2,
+      "name": "Some Note",
+      "notes": "This is a note sample.",
+      "favorite": false,
+      "secureNote": {
+        "type": 0
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "098e3ac2-f485-407f-b094-a80c00efe83c",
+      "organizationId": null,
+      "folderId": null,
+      "type": 1,
+      "name": "Some note only item",
+      "notes": "Hello World!",
+      "favorite": true,
+      "login": {
+        "username": null,
+        "password": null,
+        "totp": null
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "40775305-9751-4818-bf31-a8a700abc17d",
+      "organizationId": null,
+      "folderId": null,
+      "type": 3,
+      "name": "Visa Card",
+      "notes": null,
+      "favorite": false,
+      "card": {
+        "cardholderName": "DOE John",
+        "brand": "Visa",
+        "number": "4111111111111111",
+        "expMonth": "4",
+        "expYear": "2024",
+        "code": "492"
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "02c654b7-c18c-49c9-9d42-abe9018a831d",
+      "organizationId": null,
+      "folderId": null,
+      "type": 4,
+      "name": "John DOE",
+      "notes": null,
+      "favorite": false,
+      "identity": {
+        "title": "M.",
+        "firstName": "John",
+        "middleName": "Rober",
+        "lastName": "DOE",
+        "address1": "6 Rose street",
+        "address2": null,
+        "address3": null,
+        "city": "New York",
+        "state": null,
+        "postalCode": null,
+        "country": null,
+        "company": null,
+        "email": "john.doe@email.com",
+        "phone": null,
+        "ssn": null,
+        "username": null,
+        "passportNumber": null,
+        "licenseNumber": null
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "c17a6a37-1868-4e07-973d-abee015b06c6",
+      "organizationId": null,
+      "folderId": "bcda1361-ed24-4b10-90ba-aad30008b3e1",
+      "type": 1,
+      "name": "test-item",
+      "notes": "Notes field allowing for freeform text input",
+      "favorite": true,
+      "fields": [
+        {
+          "name": "my text field",
+          "value": "a value",
+          "type": 0
+        },
+        {
+          "name": "my hidden field",
+          "value": "another value",
+          "type": 1
+        },
+        {
+          "name": "a boolean field which is off",
+          "value": "false",
+          "type": 2
+        },
+        {
+          "name": "a boolean field which is on",
+          "value": "true",
+          "type": 2
+        }
+      ],
+      "login": {
+        "uris": [
+          {
+            "match": null,
+            "uri": "https://test-uri-1"
+          },
+          {
+            "match": null,
+            "uri": "https://test-uri-2"
+          }
+        ],
+        "username": "username",
+        "password": "password",
+        "totp": "1019"
+      },
+      "collectionIds": null
+    }
+  ]
+}

--- a/tests/assets/db/bitwarden.csv
+++ b/tests/assets/db/bitwarden.csv
@@ -1,5 +1,5 @@
 folder,favorite,type,name,notes,fields,login_uri,login_username,login_password,login_totp
-Bank,,login,aib,,,https://onlinebanking.aib.ie,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",
+Bank,,login,aib,,,https://onlinebanking.aib.ie,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",S3K3TPI5MYA2M67V
 Emails,,login,dpbx@afoqwdr.tx,,,https://afoqwdr.tx,dpbx,9KVHnx:.S_S;cF`=CE@e\p{v6,
 Emails/WS,,login,dpbx@fner.ws,For financial purpose only!,,,dpbx,mt}h'hSUCY;SU;;A!l[8y3O:8,
 Emails,,login,dpbx@klivak.xb,This is a garbage address,,,dpbx,"2cUqe}e9}>IVZf)Ye>3C8ZN,r",
@@ -14,3 +14,5 @@ Servers,,login,ovh.com,,,https://www.ovh.com/manager/web/,bynbyjhqjz,"3Z-VW!i,j(
 Servers,,login,ovh.com,,,https://www.ovh.com/manager/web/,jsdkyvbwjn,^Vr/|o>_H8X%T]7>f}7|:U!Zs,
 CornerCases,,login,space title,,,https://nhysdo.wg,vkeelpbu,]stDKo{%pk,
 Social,,login,twitter.com,,,https://twitter.com/,ostqxi,"SoNEwvU,kJ%-cIKJ9[c#S;]jB",
+,,note,Some Note,This is a note sample.,,,,,
+,1,login,Some note only item,Hello World!,,,,,

--- a/tests/assets/db/bitwarden.csv
+++ b/tests/assets/db/bitwarden.csv
@@ -1,5 +1,5 @@
 folder,favorite,type,name,notes,fields,login_uri,login_username,login_password,login_totp
-Bank,,login,aib,,,https://onlinebanking.aib.ie,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",S3K3TPI5MYA2M67V
+Bank,,login,aib,,,https://onlinebanking.aib.ie,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",
 Emails,,login,dpbx@afoqwdr.tx,,,https://afoqwdr.tx,dpbx,9KVHnx:.S_S;cF`=CE@e\p{v6,
 Emails/WS,,login,dpbx@fner.ws,For financial purpose only!,,,dpbx,mt}h'hSUCY;SU;;A!l[8y3O:8,
 Emails,,login,dpbx@klivak.xb,This is a garbage address,,,dpbx,"2cUqe}e9}>IVZf)Ye>3C8ZN,r",
@@ -14,5 +14,3 @@ Servers,,login,ovh.com,,,https://www.ovh.com/manager/web/,bynbyjhqjz,"3Z-VW!i,j(
 Servers,,login,ovh.com,,,https://www.ovh.com/manager/web/,jsdkyvbwjn,^Vr/|o>_H8X%T]7>f}7|:U!Zs,
 CornerCases,,login,space title,,,https://nhysdo.wg,vkeelpbu,]stDKo{%pk,
 Social,,login,twitter.com,,,https://twitter.com/,ostqxi,"SoNEwvU,kJ%-cIKJ9[c#S;]jB",
-,,note,Some Note,This is a note sample.,,,,,
-,1,login,Some note only item,Hello World!,,,,,

--- a/tests/assets/db/bitwarden.json
+++ b/tests/assets/db/bitwarden.json
@@ -371,6 +371,53 @@
         "licenseNumber": null
       },
       "collectionIds": null
+    },
+    {
+      "id": "c17a6a37-1868-4e07-973d-abee015b06c6",
+      "organizationId": null,
+      "folderId": "bcda1361-ed24-4b10-90ba-aad30008b3e1",
+      "type": 1,
+      "name": "test-item",
+      "notes": "Notes field allowing for freeform text input",
+      "favorite": true,
+      "fields": [
+        {
+          "name": "my text field",
+          "value": "a value",
+          "type": 0
+        },
+        {
+          "name": "my hidden field",
+          "value": "another value",
+          "type": 1
+        },
+        {
+          "name": "a boolean field which is off",
+          "value": "false",
+          "type": 2
+        },
+        {
+          "name": "a boolean field which is on",
+          "value": "true",
+          "type": 2
+        }
+      ],
+      "login": {
+        "uris": [
+          {
+            "match": null,
+            "uri": "https://test-uri-1"
+          },
+          {
+            "match": null,
+            "uri": "https://test-uri-2"
+          }
+        ],
+        "username": "username",
+        "password": "password",
+        "totp": "1019"
+      },
+      "collectionIds": null
     }
   ]
 }

--- a/tests/assets/db/bitwarden.json
+++ b/tests/assets/db/bitwarden.json
@@ -43,7 +43,7 @@
         ],
         "username": "dpbx@fner.ws",
         "password": "ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",
-        "totp": null
+        "totp": "S3K3TPI5MYA2M67V"
       },
       "collectionIds": null
     },
@@ -293,6 +293,82 @@
         "username": "ostqxi",
         "password": "SoNEwvU,kJ%-cIKJ9[c#S;]jB",
         "totp": null
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "70488eea-fb65-4a26-a1a4-a8aa01734b3f",
+      "organizationId": null,
+      "folderId": null,
+      "type": 2,
+      "name": "Some Note",
+      "notes": "This is a note sample.",
+      "favorite": false,
+      "secureNote": {
+        "type": 0
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "098e3ac2-f485-407f-b094-a80c00efe83c",
+      "organizationId": null,
+      "folderId": null,
+      "type": 1,
+      "name": "Some note only item",
+      "notes": "Hello World!",
+      "favorite": true,
+      "login": {
+        "username": null,
+        "password": null,
+        "totp": null
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "40775305-9751-4818-bf31-a8a700abc17d",
+      "organizationId": null,
+      "folderId": null,
+      "type": 3,
+      "name": "Visa Card",
+      "notes": null,
+      "favorite": false,
+      "card": {
+        "cardholderName": "DOE John",
+        "brand": "Visa",
+        "number": "4111111111111111",
+        "expMonth": "4",
+        "expYear": "2024",
+        "code": "492"
+      },
+      "collectionIds": null
+    },
+    {
+      "id": "02c654b7-c18c-49c9-9d42-abe9018a831d",
+      "organizationId": null,
+      "folderId": null,
+      "type": 4,
+      "name": "John DOE",
+      "notes": null,
+      "favorite": false,
+      "identity": {
+        "title": "M.",
+        "firstName": "John",
+        "middleName": "Rober",
+        "lastName": "DOE",
+        "address1": "6 Rose street",
+        "address2": null,
+        "address3": null,
+        "city": "New York",
+        "state": null,
+        "postalCode": null,
+        "country": null,
+        "company": null,
+        "email": "john.doe@email.com",
+        "phone": null,
+        "ssn": null,
+        "username": null,
+        "passportNumber": null,
+        "licenseNumber": null
       },
       "collectionIds": null
     }

--- a/tests/assets/db/bitwarden.json
+++ b/tests/assets/db/bitwarden.json
@@ -43,7 +43,7 @@
         ],
         "username": "dpbx@fner.ws",
         "password": "ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",
-        "totp": "S3K3TPI5MYA2M67V"
+        "totp": null
       },
       "collectionIds": null
     },
@@ -293,129 +293,6 @@
         "username": "ostqxi",
         "password": "SoNEwvU,kJ%-cIKJ9[c#S;]jB",
         "totp": null
-      },
-      "collectionIds": null
-    },
-    {
-      "id": "70488eea-fb65-4a26-a1a4-a8aa01734b3f",
-      "organizationId": null,
-      "folderId": null,
-      "type": 2,
-      "name": "Some Note",
-      "notes": "This is a note sample.",
-      "favorite": false,
-      "secureNote": {
-        "type": 0
-      },
-      "collectionIds": null
-    },
-    {
-      "id": "098e3ac2-f485-407f-b094-a80c00efe83c",
-      "organizationId": null,
-      "folderId": null,
-      "type": 1,
-      "name": "Some note only item",
-      "notes": "Hello World!",
-      "favorite": true,
-      "login": {
-        "username": null,
-        "password": null,
-        "totp": null
-      },
-      "collectionIds": null
-    },
-    {
-      "id": "40775305-9751-4818-bf31-a8a700abc17d",
-      "organizationId": null,
-      "folderId": null,
-      "type": 3,
-      "name": "Visa Card",
-      "notes": null,
-      "favorite": false,
-      "card": {
-        "cardholderName": "DOE John",
-        "brand": "Visa",
-        "number": "4111111111111111",
-        "expMonth": "4",
-        "expYear": "2024",
-        "code": "492"
-      },
-      "collectionIds": null
-    },
-    {
-      "id": "02c654b7-c18c-49c9-9d42-abe9018a831d",
-      "organizationId": null,
-      "folderId": null,
-      "type": 4,
-      "name": "John DOE",
-      "notes": null,
-      "favorite": false,
-      "identity": {
-        "title": "M.",
-        "firstName": "John",
-        "middleName": "Rober",
-        "lastName": "DOE",
-        "address1": "6 Rose street",
-        "address2": null,
-        "address3": null,
-        "city": "New York",
-        "state": null,
-        "postalCode": null,
-        "country": null,
-        "company": null,
-        "email": "john.doe@email.com",
-        "phone": null,
-        "ssn": null,
-        "username": null,
-        "passportNumber": null,
-        "licenseNumber": null
-      },
-      "collectionIds": null
-    },
-    {
-      "id": "c17a6a37-1868-4e07-973d-abee015b06c6",
-      "organizationId": null,
-      "folderId": "bcda1361-ed24-4b10-90ba-aad30008b3e1",
-      "type": 1,
-      "name": "test-item",
-      "notes": "Notes field allowing for freeform text input",
-      "favorite": true,
-      "fields": [
-        {
-          "name": "my text field",
-          "value": "a value",
-          "type": 0
-        },
-        {
-          "name": "my hidden field",
-          "value": "another value",
-          "type": 1
-        },
-        {
-          "name": "a boolean field which is off",
-          "value": "false",
-          "type": 2
-        },
-        {
-          "name": "a boolean field which is on",
-          "value": "true",
-          "type": 2
-        }
-      ],
-      "login": {
-        "uris": [
-          {
-            "match": null,
-            "uri": "https://test-uri-1"
-          },
-          {
-            "match": null,
-            "uri": "https://test-uri-2"
-          }
-        ],
-        "username": "username",
-        "password": "password",
-        "totp": "1019"
       },
       "collectionIds": null
     }

--- a/tests/assets/references/bitwarden-other.yml
+++ b/tests/assets/references/bitwarden-other.yml
@@ -1,0 +1,50 @@
+---
+
+- title: aib
+  password: "ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14"
+  login: dpbx@fner.ws
+  url: https://onlinebanking.aib.ie
+  group: Bank
+  otpauth: "S3K3TPI5MYA2M67V"
+
+- title: Some Note
+  comments: "This is a note sample."
+  group: CornerCases
+
+- title: Some note only item
+  comments: "Hello World!"
+
+- title: Visa Card
+  brand: Visa
+  cardholderName: DOE John
+  code: 492
+  expMonth: 4
+  expYear: 2024
+  number: 4111111111111111
+
+- title: John DOE
+  address1: 6 Rose street
+  address2: None
+  address3: None
+  city: New York
+  company: None
+  country: None
+  email: john.doe@email.com
+  firstName: John
+  lastName: DOE
+  licenseNumber: None
+  middleName: Rober
+  passportNumber: None
+  phone: None
+  postalCode: None
+  ssn: None
+  username: None
+  passportNumber: None
+  licenseNumber: None
+
+- title: test-item
+  comments: "Notes field allowing for freeform text input"
+  my text field: a value
+  my hidden field: another value
+  a boolean field which is off: false
+  a boolean field which is on: true

--- a/tests/assets/references/bitwarden-other.yml
+++ b/tests/assets/references/bitwarden-other.yml
@@ -17,34 +17,29 @@
 - title: Visa Card
   brand: Visa
   cardholderName: DOE John
-  code: 492
-  expMonth: 4
-  expYear: 2024
-  number: 4111111111111111
+  code: '492'
+  expMonth: '4'
+  expYear: '2024'
+  number: '4111111111111111'
 
 - title: John DOE
   address1: 6 Rose street
-  address2: None
-  address3: None
   city: New York
-  company: None
-  country: None
   email: john.doe@email.com
+  title_: M.
   firstName: John
   lastName: DOE
-  licenseNumber: None
   middleName: Rober
-  passportNumber: None
-  phone: None
-  postalCode: None
-  ssn: None
-  username: None
-  passportNumber: None
-  licenseNumber: None
 
 - title: test-item
   comments: "Notes field allowing for freeform text input"
   my text field: a value
   my hidden field: another value
-  a boolean field which is off: false
-  a boolean field which is on: true
+  a boolean field which is off: 'false'
+  a boolean field which is on: 'true'
+  login: username
+  password: password
+  otpauth: '1019'
+  url: https://test-uri-1
+  url2: https://test-uri-2
+  group: Emails

--- a/tests/imports/test_parse.py
+++ b/tests/imports/test_parse.py
@@ -16,6 +16,7 @@ REFERENCE_CARD = tests.yaml_load('encryptr-card.yml')
 REFERENCE_OTHER = tests.yaml_load('keepass-other.yml')
 REFERENCE_KDBX = tests.yaml_load('keepass-kdbx.yml')
 REFERENCE_REVELATION = tests.yaml_load('revelation-other.yml')
+REFERENCE_BITWARDEN = tests.yaml_load('bitwarden-other.yml')
 
 
 class TestParse(tests.Test):
@@ -164,3 +165,22 @@ class TestParse(tests.Test):
         with tests.cls('Revelation', prefix) as importer:
             importer.parse()
             self.assertImport(importer.data, REFERENCE_REVELATION, keep)
+
+    def test_importers_bitwarden(self):
+        """Testing: parse method for Bitwarden with special cases."""
+        keep = [
+            'title', 'password', 'login', 'database', 'host', 'port', 'url',
+            'email', 'phone', 'location', 'description', 'comments', 'group',
+            'otpauth', 'title', 'brand', 'cardholderName', 'code', 'expMonth',
+            'expYear', 'number', 'title', 'address1', 'address2', 'address3',
+            'city', 'company', 'country', 'email', 'firstName', 'lastName',
+            'licenseNumber', 'middleName', 'passportNumber', 'phone',
+            'postalCode', 'ssn', 'username', 'passportNumber',
+            'licenseNumber', 'title', 'comments', 'my text field',
+            'my hidden field', 'a boolean field which is off',
+            'a boolean field which is on', 'secureNote'
+        ]
+        prefix = os.path.join(tests.db, 'bitwarden-other.json')
+        with tests.cls('BitwardenJSON', prefix) as importer:
+            importer.parse()
+            self.assertImport(importer.data, REFERENCE_BITWARDEN, keep)

--- a/tests/imports/test_parse.py
+++ b/tests/imports/test_parse.py
@@ -178,7 +178,7 @@ class TestParse(tests.Test):
             'postalCode', 'ssn', 'username', 'passportNumber',
             'licenseNumber', 'title', 'comments', 'my text field',
             'my hidden field', 'a boolean field which is off',
-            'a boolean field which is on', 'secureNote'
+            'a boolean field which is on', 'secureNote', 'title_', 'url2'
         ]
         prefix = os.path.join(tests.db, 'bitwarden-other.json')
         with tests.cls('BitwardenJSON', prefix) as importer:


### PR DESCRIPTION
Make Bitwarden import more flexible:
* Import fields from other kinds of Bitwarden vault items
* Import custom fields
* If a vault item has multiple URLs, import all of them
* Add test covering the above

Note: this doesn't affect imports unless `pass import` is called with `--all`.

This builds on top of @quentin-bettoum's work gathering samples in https://github.com/roddhjav/pass-import/pull/108. I split the new Bitwarden-specific behavior into a test separate from the generic one.

This fixes #110 and #107.